### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/knxReTk/busaccess/layer.py
+++ b/knxReTk/busaccess/layer.py
@@ -296,7 +296,7 @@ class DispatcherThread(Thread):
             if message:
                 serviceHandler = self.layer.SERVICES.get(message.service)
                 if serviceHandler is None:
-                    raise ServiceError("Invalid Service Code: 0x%02x" % message.service)
+                    raise ServiceError("Invalid Service Code: 0x{0:02x}".format(message.service))
                 serviceHandler(self.layer, message)
                 self.layer.queue.task_done()
 
@@ -318,7 +318,7 @@ class Layer(SingletonBase):
         else:
             serviceGroup = message.service & 0xf0
             if serviceGroup not in Layer.serviceRegistry:
-                raise ServiceError("Service Group unknwon: 0x%02x" % serviceGroup)
+                raise ServiceError("Service Group unknwon: 0x{0:02x}".format(serviceGroup))
             instance, services = Layer.serviceRegistry.get(serviceGroup)
             instance.queue.put(message, block = True)
 

--- a/knxReTk/busaccess/phyTpuart.py
+++ b/knxReTk/busaccess/phyTpuart.py
@@ -269,12 +269,12 @@ def makeComparator(mask, compareTo):
 class State(SingletonBase):
 
     def __str_(self):
-        return "State[%s]" % self.__class__.__name__
+        return "State[{0!s}]".format(self.__class__.__name__)
 
 class Event(SingletonBase):
 
     def __str_(self):
-        return "Event[%s]" % self.__class__.__name__
+        return "Event[{0!s}]".format(self.__class__.__name__)
 
 
 ##
@@ -385,7 +385,7 @@ class TransmissionCommand(BaseProcessor):
         else:
             #assert (octet & REPETITION_MASK) == (self.parent.sendBuffer[0] & REPETITION_MASK)
             if not ((octet & REPETITION_MASK) == (self.parent.sendBuffer[0] & REPETITION_MASK)):
-                print "Uups [first]: '%02x' != '%02x'" % (octet, self.parent.sendBuffer[0], )
+                print "Uups [first]: '{0:02x}' != '{1:02x}'".format(octet, self.parent.sendBuffer[0] )
             self.idx = 1
             self.repetitionCounter += 1
             self.action = self.consecutive
@@ -415,7 +415,7 @@ class TransmissionCommand(BaseProcessor):
             #print "%02x %02x" % (octet, self.parent.sendBuffer[0])
             #assert octet & REPETITION_MASK == self.parent.sendBuffer[0] & REPETITION_MASK
             if not ((octet & REPETITION_MASK) == (self.parent.sendBuffer[0] & REPETITION_MASK)):
-                print "Uups []first: '%02x' != '%02x'" % (octet, self.parent.sendBuffer[0], )
+                print "Uups []first: '{0:02x}' != '{1:02x}'".format(octet, self.parent.sendBuffer[0] )
         self.repeated = not (octet & ~REPETITION_MASK == ~REPETITION_MASK)
         #if self.repeated:
         #    print "   *** Repeated!!"

--- a/knxReTk/busaccess/stdids.py
+++ b/knxReTk/busaccess/stdids.py
@@ -114,13 +114,13 @@ PROPERTY_DATA_TYPES = {
 
 def objectType(value):
     result = OBJECT_TYPES.get(value, '')
-    return "%s[%u]" % (result, value)
+    return "{0!s}[{1:d}]".format(result, value)
 
 def propertyIdentifier(value):
     result = PROPERTY_IDENTIFIERS.get(value, '')
-    return "%s[%u]" % (result, value)
+    return "{0!s}[{1:d}]".format(result, value)
 
 def propertyDataType(value):
     result = PROPERTY_DATA_TYPES.get(value, '')
-    return "%s[%u]" % (result, value)
+    return "{0!s}[{1:d}]".format(result, value)
 

--- a/knxReTk/busaccess/tlc.py
+++ b/knxReTk/busaccess/tlc.py
@@ -227,7 +227,7 @@ class StateMachine(SingletonBase):
         self.stopAcknowledgeTimeoutTimer()
 
     def __call__(self, event):
-        print "State: %s - Event: %s" % (StateType.toString(self._state), EventType.toString(event), ),
+        print "State: {0!s} - Event: {1!s}".format(StateType.toString(self._state), EventType.toString(event) ),
 
         eventHandler = self.EVENT_HANDLER[event]
         entry = StateMachine.STATE_TABLE[eventHandler(self)]
@@ -347,7 +347,7 @@ class StateMachine(SingletonBase):
         #  Destination = source (rbuffer), Sequence = 0 back to sender. */
 
         frame = self.message.asStandardFrame()
-        print "t_Disconnect_Req from: %04x to: %04x" % (frame.dest, frame.source, )
+        print "t_Disconnect_Req from: {0:04x} to: {1:04x}".format(frame.dest, frame.source )
         self.parent.t_Disconnect_Req(frame.dest, frame.source)
 
     def A11(self):
@@ -457,7 +457,7 @@ class StateMachine(SingletonBase):
         else:
             eventNum = 10
             print "NOT-OK, sourceAddr != connectionAddr!"
-            print "<<%04X>><<%04X>>" % (self.sourceAddress, self.connectionAddress, )
+            print "<<{0:04X}>><<{1:04X}>>".format(self.sourceAddress, self.connectionAddress )
         return eventNum
 
     def Event_Nak_Ind(self):

--- a/knxReTk/catalogue/ets4.py
+++ b/knxReTk/catalogue/ets4.py
@@ -52,13 +52,13 @@ def escape_(value):
         result = []
         for ch in value:
             if not ch.isalnum():
-                result.append(".%02X" % ord(ch))
+                result.append(".{0:02X}".format(ord(ch)))
             else:
                 result.append(ch)
         return ''.join(result)
 
 def nonAlNumReplacer(match):
-    return ".%X" % ord(match.group())
+    return ".{0:X}".format(ord(match.group()))
 
 def escape(text):
     return NON_ALNUM.sub(nonAlNumReplacer, text)

--- a/knxReTk/catalogue/locales.py
+++ b/knxReTk/catalogue/locales.py
@@ -385,7 +385,7 @@ def getLocalCode(locale):
     result = LOCALS.get(locale, ('?', '?', '?', ))[2]
     if '-' in result:
         l, r = result.split('-')
-        return "%s-%s" % (l.lower(), r.upper())
+        return "{0!s}-{1!s}".format(l.lower(), r.upper())
     else:
         return result
 

--- a/knxReTk/catalogue/vd_exporter.py
+++ b/knxReTk/catalogue/vd_exporter.py
@@ -122,7 +122,7 @@ class Dummy(object):
     def __str__(self):
         result = []
         for key in [x for x in dir(self) if not (x.startswith('_'))]:
-            result.append("%s = '%s'" % (key, getattr(self, key)))
+            result.append("{0!s} = '{1!s}'".format(key, getattr(self, key)))
         return '\n'.join(result)
 
 
@@ -231,10 +231,10 @@ class CatalogueReverser(object): # TODO: Strategy
 
         _, relpath = os.path.splitdrive(path)
         fname, _ = os.path.splitext(relpath)
-        self.outf = codecs.open('%s.xml' % fname, mode = 'w', encoding = "utf-8")
-        self.logFile = codecs.open('%s.log' % fname, mode = 'w', encoding = "utf-8")
+        self.outf = codecs.open('{0!s}.xml'.format(fname), mode = 'w', encoding = "utf-8")
+        self.logFile = codecs.open('{0!s}.log'.format(fname), mode = 'w', encoding = "utf-8")
         #self.logFile = sys.stdout
-        print 'TARGET FILE: %s.xml' % fname
+        print 'TARGET FILE: {0!s}.xml'.format(fname)
 
     def _getLine(self):
         line = unicode(self.data[self.pos], 'latin-1')
@@ -273,9 +273,9 @@ class CatalogueReverser(object): # TODO: Strategy
 
     def checkSignature(self):
         if self.data[0] != MAGIC_SIG:
-            raise FormatError("Catalogue doesn't start with '%s'." % MAGIC_SIG)
+            raise FormatError("Catalogue doesn't start with '{0!s}'.".format(MAGIC_SIG))
         if self.data[-1] != EOF_SIG:
-            raise FormatError("Catalogue doesn't end with '%s'." % EOF_SIG)
+            raise FormatError("Catalogue doesn't end with '{0!s}'.".format(EOF_SIG))
 
     def parseFileHeader(self):
         ATTRIBUTE_MAP = {
@@ -290,8 +290,8 @@ class CatalogueReverser(object): # TODO: Strategy
         for tag, content in filter(lambda x: len(x) == 2, [string.split(l, maxsplit = 1) for l in block[1:]]):
             setattr(header, ATTRIBUTE_MAP[tag], content)
         setattr(self, 'header', header)
-        print "HEADER: \n%s\n\n" % header
-        self.logFile.write("%s\n\n" % header)
+        print "HEADER: \n{0!s}\n\n".format(header)
+        self.logFile.write("{0!s}\n\n".format(header))
 
     def parseTables(self):
         idx = 0
@@ -300,7 +300,7 @@ class CatalogueReverser(object): # TODO: Strategy
         columnIdx = 0
         columnBuilder = ColumnBuilder()
         rowBuilder = RowBuilder()
-        self.outf.write("%s\n" % XML_DECL)
+        self.outf.write("{0!s}\n".format(XML_DECL))
         if hasattr(self.header, 'originalFilename'):
             originalFilename = self.header.originalFilename
         else:
@@ -316,7 +316,7 @@ class CatalogueReverser(object): # TODO: Strategy
             date = ''
         version = self.header.version
         rootTable = self.header.rootTable
-        self.outf.write('<CATALOGUE originalFilename="%s" creator="%s" date="%s" version="%s" rootTable="%s" >\n' % (
+        self.outf.write('<CATALOGUE originalFilename="{0!s}" creator="{1!s}" date="{2!s}" version="{3!s}" rootTable="{4!s}" >\n'.format(
             originalFilename, creator, date, version, rootTable)
         )
         while not finished:
@@ -333,10 +333,10 @@ class CatalogueReverser(object): # TODO: Strategy
                         TableNamesToNumbers[ma.group("name")].add(ma.group("tableNumber"))
 
                         tb = TableBuilder(ma.group("name"), ma.group("tableNumber"))
-                        self.outf.write("    <%sS>\n" % tb.name.upper())
+                        self.outf.write("    <{0!s}S>\n".format(tb.name.upper()))
                         self.state = STATE_COLUMN
                     else:
-                        raise FormatError("Expected table declaration [%u]: '%s'." % (lineNumber, line))
+                        raise FormatError("Expected table declaration [{0:d}]: '{1!s}'.".format(lineNumber, line))
                 elif self.state == STATE_COLUMN:
                     ma = COL_DESC.match(line)
                     if ma:
@@ -349,13 +349,13 @@ class CatalogueReverser(object): # TODO: Strategy
                             tableNumber = int(ma.group('tableNumber'))
                             rowNumber = int(ma.group('rowNumber'))
                             columnIdx = 1
-                            self.outf.write("        <%s>\n" % tb.name.upper())
+                            self.outf.write("        <{0!s}>\n".format(tb.name.upper()))
                             self.state = STATE_ROW
-                            self.logFile.write("%s[%u]\n" % (tb.name, tb.number))
-                            print("%s[%u]\n" % (tb.name, tb.number))
+                            self.logFile.write("{0!s}[{1:d}]\n".format(tb.name, tb.number))
+                            print("{0!s}[{1:d}]\n".format(tb.name, tb.number))
                             for column in tb.columns:
-                                self.logFile.write("    %s[%u]::%s %s\n" % (column.name, column.colNumber, column.type_, column.nulls))
-                                print("    %s[%u]::%s %s\n" % (column.name, column.colNumber, column.type_, column.nulls))
+                                self.logFile.write("    {0!s}[{1:d}]::{2!s} {3!s}\n".format(column.name, column.colNumber, column.type_, column.nulls))
+                                print("    {0!s}[{1:d}]::{2!s} {3!s}\n".format(column.name, column.colNumber, column.type_, column.nulls))
                             self.logFile.write("\n")
                 elif self.state == STATE_ROW:
                     columnBuilder.add(line)
@@ -381,9 +381,9 @@ class CatalogueReverser(object): # TODO: Strategy
                                 if value:
                                     #if isinstance(value, basestring):
                                     #    value = value.encode("utf-8")
-                                    self.outf.write("            <%s>%s</%s>\n" % (name, value, name))
+                                    self.outf.write("            <{0!s}>{1!s}</{2!s}>\n".format(name, value, name))
                             self.state = STATE_ROW_IND
-                            self.outf.write("        </%s>\n" % tb.name.upper())
+                            self.outf.write("        </{0!s}>\n".format(tb.name.upper()))
                 elif self.state == STATE_ROW_IND:
                     if not columnBuilder.finished:
                         raise Exception("Uups!")
@@ -393,10 +393,10 @@ class CatalogueReverser(object): # TODO: Strategy
                         rowNumber = int(ma.group('rowNumber'))
                         columnIdx = 1
                         self.state = STATE_ROW
-                        self.outf.write("        <%s>\n" % tb.name.upper())
+                        self.outf.write("        <{0!s}>\n".format(tb.name.upper()))
                     else:
-                        raise FormatError("Expected row indicator [%u]: '%s'." % (lineNumber, line))
-            self.outf.write("    </%sS>\n" % tb.name.upper())
+                        raise FormatError("Expected row indicator [{0:d}]: '{1!s}'.".format(lineNumber, line))
+            self.outf.write("    </{0!s}S>\n".format(tb.name.upper()))
         self.outf.write("</CATALOGUE>\n")
 
     def parseTableHeader(self):

--- a/knxReTk/config/symbols.py
+++ b/knxReTk/config/symbols.py
@@ -70,7 +70,7 @@ class Symbols(object):
                     if arraySize:
                         #self.sections[currentSection].append(ArrayProperty(prop, value, int(arraySize), ))
                         for offset in range(int(arraySize)):
-                            self.sections[currentSection].append(ValueProperty("%s + %u" % (prop, offset), value + offset, ))
+                            self.sections[currentSection].append(ValueProperty("{0!s} + {1:d}".format(prop, offset), value + offset, ))
                     else:
                         self.sections[currentSection].append(ValueProperty(prop, value, ))
                 else:
@@ -84,7 +84,7 @@ class Symbols(object):
                         x = True if 'X' in attribs else False
                         self.sections[currentSection].append(MemorySection(start, end, r, w, x, ))
                     else:
-                        print "*** NO MATCH [%s] ***" % line
+                        print "*** NO MATCH [{0!s}] ***".format(line)
         self._items = {}
         for name, section in self.sections.items():
             if (name[0] == mask or name[0] == mcu) or (name[0] == 'EIBCommon' or name[0] == 'EEPROMProlog'):

--- a/knxReTk/executionModel/memory.py
+++ b/knxReTk/executionModel/memory.py
@@ -67,7 +67,7 @@ class Memory(object):
         elif endianess == Memory.LITTLE_ENDIAN:
             return getL
         else:
-            raise ValueError("Invalid endianess '%s'." % endianess)
+            raise ValueError("Invalid endianess '{0!s}'.".format(endianess))
 
     def getBlob(self, addr, size):
         return self._image[addr : addr + size]
@@ -103,7 +103,7 @@ class ReadWriteMemory(Memory):
         elif endianess == Memory.LITTLE_ENDIAN:
             return setL
         else:
-            raise ValueError("Invalid endianess '%s'." % endianess)
+            raise ValueError("Invalid endianess '{0!s}'.".format(endianess))
 
 
 ##

--- a/knxReTk/toolServer/serve.py
+++ b/knxReTk/toolServer/serve.py
@@ -150,7 +150,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.conn = conn
 
     def set_default_headers(self):
-        self.set_header('Server', '%s/%s' % (SERVER_NAME, SERVER_VERSION))
+        self.set_header('Server', '{0!s}/{1!s}'.format(SERVER_NAME, SERVER_VERSION))
 
     def write(self, chunk, contentType = None):
         acceptedEncodings = self.request.headers.get('accept-encoding', '')

--- a/knxReTk/utilz/classes.py
+++ b/knxReTk/utilz/classes.py
@@ -54,17 +54,17 @@ class RepresentationMixIn(object):
     def __repr__(self):
         keys = [k for k in self.__dict__ if not (k.startswith('__') and k.endswith('__'))]
         result = []
-        result.append("%s {" % self.__class__.__name__)
+        result.append("{0!s} {{".format(self.__class__.__name__))
         for key in keys:
             value = getattr(self, key)
             if isinstance(value, (int, long)):
-                line = "    %s = 0x%X" % (key, value)
+                line = "    {0!s} = 0x{1:X}".format(key, value)
             elif isinstance(value, (float, types.NoneType)):
-                line = "    %s = %s" % (key, value)
+                line = "    {0!s} = {1!s}".format(key, value)
             elif isinstance(value, array):
-                line = "    %s = %s" % (key, helper.hexDump(value))
+                line = "    {0!s} = {1!s}".format(key, helper.hexDump(value))
             else:
-                line = "    %s = '%s'" % (key, value)
+                line = "    {0!s} = '{1!s}'".format(key, value)
             result.append(line)
         result.append("}")
         return '\n'.join(result)

--- a/knxReTk/utilz/config.py
+++ b/knxReTk/utilz/config.py
@@ -43,12 +43,12 @@ def homeDirectory():
 def projectConfigurationDirectory(project):
     path = os.path.join(homeDirectory(), project)
     if not os.access(path, os.F_OK):
-        logger.info("Creating configuration directory '%s'" % path)
+        logger.info("Creating configuration directory '{0!s}'".format(path))
         os.mkdir(path)
         print
     return path
 
 def readConfigData(project, fname):
-    return pkgutil.get_data(project, 'config/%s' % fname)
+    return pkgutil.get_data(project, 'config/{0!s}'.format(fname))
 
 

--- a/knxReTk/utilz/helper.py
+++ b/knxReTk/utilz/helper.py
@@ -32,7 +32,7 @@ __version__ = '0.1.0'
 import operator
 
 def hexDump(data):
-    return ', '.join(["0x%02x" % x for x in data])
+    return ', '.join(["0x{0:02x}".format(x) for x in data])
 
 checksum = lambda frame: reduce(operator.xor, frame, 0xff)
 

--- a/knxReTk/utilz/knx_escape.py
+++ b/knxReTk/utilz/knx_escape.py
@@ -52,7 +52,7 @@ def escape(value):
         result = []
         for ch in value:
             if not ch.isalnum():
-                result.append(".%02X" % ord(ch))
+                result.append(".{0:02X}".format(ord(ch)))
             else:
                 result.append(ch)
         return ''.join(result)

--- a/knxReTk/utilz/locales.py
+++ b/knxReTk/utilz/locales.py
@@ -208,7 +208,7 @@ def getLocalCode(locale):
     result = LOCALS.get(locale, ('?', '?', '?', ))[2]
     if '-' in result:
         l, r = result.split('-')
-        return "%s-%s" % (l.lower(), r.upper())
+        return "{0!s}-{1!s}".format(l.lower(), r.upper())
     else:
         return result
 

--- a/knxReTk/utilz/profilehooks.py
+++ b/knxReTk/utilz/profilehooks.py
@@ -207,8 +207,7 @@ def profile(fn=None, skip=0, filename=None, immediate=False, dirs=False,
             profiler_class = AVAILABLE_PROFILERS[p]
             break
     else:
-        raise ValueError('only these profilers are available: %s'
-                             % ', '.join(AVAILABLE_PROFILERS))
+        raise ValueError('only these profilers are available: {0!s}'.format(', '.join(AVAILABLE_PROFILERS)))
     fp = profiler_class(fn, skip=skip, filename=filename,
                         immediate=immediate, dirs=dirs,
                         sort=sort, entries=entries)
@@ -337,10 +336,10 @@ class FuncProfile(object):
         lineno = self.fn.func_code.co_firstlineno
         print
         print "*** PROFILER RESULTS ***"
-        print "%s (%s:%s)" % (funcname, filename, lineno)
-        print "function called %d times" % self.ncalls,
+        print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+        print "function called {0:d} times".format(self.ncalls),
         if self.skipped:
-            print "(%d calls not profiled)" % self.skipped
+            print "({0:d} calls not profiled)".format(self.skipped)
         else:
             print
         print
@@ -440,10 +439,10 @@ if hotshot is not None:
             lineno = self.fn.func_code.co_firstlineno
             print
             print "*** PROFILER RESULTS ***"
-            print "%s (%s:%s)" % (funcname, filename, lineno)
-            print "function called %d times" % self.ncalls,
+            print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+            print "function called {0:d} times".format(self.ncalls),
             if self.skipped:
-                print "(%d calls not profiled)" % self.skipped
+                print "({0:d} calls not profiled)".format(self.skipped)
             else:
                 print
             print
@@ -503,8 +502,8 @@ if hotshot is not None:
             lineno = self.fn.func_code.co_firstlineno
             print
             print "*** COVERAGE RESULTS ***"
-            print "%s (%s:%s)" % (funcname, filename, lineno)
-            print "function called %d times" % self.ncalls
+            print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+            print "function called {0:d} times".format(self.ncalls)
             print
             fs = FuncSource(self.fn)
             reader = hotshot.log.LogReader(self.logfilename)
@@ -577,8 +576,8 @@ class TraceFuncCoverage:
         lineno = self.fn.func_code.co_firstlineno
         print
         print "*** COVERAGE RESULTS ***"
-        print "%s (%s:%s)" % (funcname, filename, lineno)
-        print "function called %d times" % self.ncalls
+        print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+        print "function called {0:d} times".format(self.ncalls)
         print
         fs = FuncSource(self.fn)
         for (filename, lineno), count in self.tracer.counts.items():
@@ -588,7 +587,7 @@ class TraceFuncCoverage:
         print fs
         never_executed = fs.count_never_executed()
         if never_executed:
-            print "%d lines were not executed." % never_executed
+            print "{0:d} lines were not executed.".format(never_executed)
 
 
 class FuncSource:
@@ -647,7 +646,7 @@ class FuncSource:
                 else:
                     prefix = '>' * 6 + ' '
             else:
-                prefix = '%5d: ' % counter
+                prefix = '{0:5d}: '.format(counter)
             lines.append(prefix + line)
             lineno += 1
         return ''.join(lines)
@@ -711,7 +710,7 @@ class FuncTimer(object):
                 funcname = fn.__name__
                 filename = fn.func_code.co_filename
                 lineno = fn.func_code.co_firstlineno
-                print >> sys.stderr, "\n  %s (%s:%s):\n    %.3f seconds\n" % (
+                print >> sys.stderr, "\n  {0!s} ({1!s}:{2!s}):\n    {3:.3f} seconds\n".format(
                                         funcname, filename, lineno, duration)
     def atexit(self):
         if not self.ncalls:

--- a/knxReTk/utilz/strings.py
+++ b/knxReTk/utilz/strings.py
@@ -111,10 +111,10 @@ def reformat(text, leftMargin = 1, rightMargin = 80):
         line = ' ' * (leftMargin - 1)
         for word in origLine.split():
             if (len(line) + len(word) - leftMargin + 1) <= (rightMargin - leftMargin):
-                line += "%s " % word
+                line += "{0!s} ".format(word)
             else:
                 resultLines.append(line.rstrip())
-                line = "%s%s " % ((' ' * (leftMargin - 1)) , word)
+                line = "{0!s}{1!s} ".format((' ' * (leftMargin - 1)) , word)
         resultLines.append(line.rstrip())
     return '\n'.join(resultLines)
 

--- a/knxReTk/utilz/templates.py
+++ b/knxReTk/utilz/templates.py
@@ -40,7 +40,7 @@ from mako import exceptions
 
 from knxReTk.utilz import strings
 
-indentText = lambda text, leftmargin = 0: '\n'.join(["%s%s" % ((" " * leftmargin), line, ) for line in text.splitlines()])
+indentText = lambda text, leftmargin = 0: '\n'.join(["{0!s}{1!s}".format((" " * leftmargin), line ) for line in text.splitlines()])
 
 
 def renderTemplate(filename = None, text = None, namespace = {}, leftMargin = 0, rightMargin = 80, formatExceptions = True, encoding = 'utf-8'):

--- a/knxReTk/utilz/threads.py
+++ b/knxReTk/utilz/threads.py
@@ -51,7 +51,7 @@ class Thread(threading.Thread):
             thread.quit()
 
     def getName(self):
-        return "%s-%u" % (self.__class__.__name__, self.ident)
+        return "{0!s}-{1:d}".format(self.__class__.__name__, self.ident)
 
     def run(self):
         #print "Starting {0} thread.".format(self.getName())

--- a/knxReTk/vdimex/ets_loader.py
+++ b/knxReTk/vdimex/ets_loader.py
@@ -53,7 +53,7 @@ try:
     mongoClient = getMongoClient()
     bootstrap.init(mongoClient)
 except Exception as e:
-    print "Problem with Database Connection: '%s'." % str(e)
+    print "Problem with Database Connection: '{0!s}'.".format(str(e))
     print "Exiting."
     sys.exit(1)
 

--- a/knxReTk/vdimex/loader.py
+++ b/knxReTk/vdimex/loader.py
@@ -129,7 +129,7 @@ class Dummy(object):
     def __str__(self):
         result = []
         for key in [x for x in dir(self) if not (x.startswith('_'))]:
-            result.append("%s = '%s'" % (key, getattr(self, key)))
+            result.append("{0!s} = '{1!s}'".format(key, getattr(self, key)))
         return '\n'.join(result)
 
 
@@ -284,9 +284,9 @@ class CatalogueReverser(object):
 
     def checkSignature(self):
         if self.data[0] != MAGIC_SIG:
-            raise FormatError("Catalogue doesn't start with '%s'." % MAGIC_SIG)
+            raise FormatError("Catalogue doesn't start with '{0!s}'.".format(MAGIC_SIG))
         if self.data[-1] != EOF_SIG:
-            raise FormatError("Catalogue doesn't end with '%s'." % EOF_SIG)
+            raise FormatError("Catalogue doesn't end with '{0!s}'.".format(EOF_SIG))
 
     def parseFileHeader(self):
         ATTRIBUTE_MAP = {
@@ -341,7 +341,7 @@ class CatalogueReverser(object):
 
                         self.state = STATE_COLUMN
                     else:
-                        raise FormatError("Expected table declaration [%u]: '%s'." % (lineNumber, line))
+                        raise FormatError("Expected table declaration [{0:d}]: '{1!s}'.".format(lineNumber, line))
                 elif self.state == STATE_COLUMN:
                     ma = COL_DESC.match(line)
                     if ma:
@@ -388,7 +388,7 @@ class CatalogueReverser(object):
                         columnIdx = 1
                         self.state = STATE_ROW
                     else:
-                        raise FormatError("Expected row indicator [%u]: '%s'." % (lineNumber, line))
+                        raise FormatError("Expected row indicator [{0:d}]: '{1!s}'.".format(lineNumber, line))
             self.endTable(tb.name)
 
         self.onFinished()

--- a/knxReTk/vdimex/xmlloader/parser.py
+++ b/knxReTk/vdimex/xmlloader/parser.py
@@ -68,7 +68,7 @@ class XMLHandler(ContentHandler):
         self.level += 1
         self.tags.append(name)
 
-        callback = "on%sStart" % name
+        callback = "on{0!s}Start".format(name)
         if hasattr(self, callback):
             getattr(self, callback)(name, attrs)
         else:
@@ -89,7 +89,7 @@ class XMLHandler(ContentHandler):
     def endElement(self, name):
         if ':' in name:
             namespace, name = name.split(':')
-        callback = "on%sEnd" % name
+        callback = "on{0!s}End".format(name)
         if hasattr(self, callback):
             getattr(self, callback)(name)
         #self.currentElement['textContent'] = ''

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 from glob import glob
 
 def packagez(base):
-    return  ["%s%s%s" % (base, os.path.sep, p) for p in find_packages(base)]
+    return  ["{0!s}{1!s}{2!s}".format(base, os.path.sep, p) for p in find_packages(base)]
 
 setup(
     name = 'knxReTk',


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:christoph2:knx?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:christoph2:knx?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
